### PR TITLE
Zend_Controller_Exception needs to be loaded

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -43,6 +43,7 @@ include "Zend/Loader.php";
 
 Zend_Loader::loadClass('Zend_Auth');
 Zend_Loader::loadClass('Zend_Controller_Front');
+Zend_Loader::loadClass('Zend_Controller_Exception');
 Zend_Loader::loadClass('Zend_Cache');
 Zend_Loader::loadClass('Zend_Session');
 Zend_Loader::loadClass('MyClass_Session_SaveHandler_DbTable'); // PHP session storage


### PR DESCRIPTION
Need to load this class in order to show error properly (for example when Bacula DB tables don't exist), otherwise it will fail with :
Class 'Zend_Controller_Exception' not found in library/Zend/Controller/Plugin/Broker.php on line 336
